### PR TITLE
pass cb even when non-lazy loading

### DIFF
--- a/src/svg.textmorph.js
+++ b/src/svg.textmorph.js
@@ -53,7 +53,7 @@ SVG.SVGFont = SVG.invent({
     }.bind(this)
 
     try{
-      fontLoadedCb(parseXML(source))
+      fontLoadedCb(parseXML(source), cb)
     }catch(e){
       node = document.getElementById(source)
       node ? fontLoadedCb(node) : loadFont(source, function(node){  fontLoadedCb(node, cb)  })


### PR DESCRIPTION
This fixes a bug where the parameter `cb` was not being passed, so the call to `fontLoadedCb` would throw an error when it tries to call the callback.